### PR TITLE
remove event listeners from clock start functions as causing clock is…

### DIFF
--- a/src/main/webapp/WEB-INF/jsp/scoreboard.jsp
+++ b/src/main/webapp/WEB-INF/jsp/scoreboard.jsp
@@ -41,6 +41,21 @@
             setDefaultValues();
         }
 
+        gameClock.addEventListener('secondTenthsUpdated', function (e) {
+            //console.log("GAME CLOCK",gameClock.getTimeValues());
+            if(gameClock.getTimeValues().minutes === 0){
+                $("#gameClockMins").html(padDigits(gameClock.getTimeValues().seconds));
+                $("#gameClockSecs").html(gameClock.getTimeValues().secondTenths);
+            }else{
+                $("#gameClockMins").html(padDigits(gameClock.getTimeValues().minutes));
+                $("#gameClockSecs").html(padDigits(gameClock.getTimeValues().seconds));
+            }
+        });
+
+        shotClock.addEventListener('secondTenthsUpdated', function (e) {
+            $("#shotClockSecs").html(padDigits(shotClock.getTimeValues().seconds));
+        });
+
         function startClocks(gameClockTenthsSecs, shotClockTenthsSecs) {
 
             //stop clocks and reset
@@ -56,16 +71,6 @@
                 $("#gameClockMins").html(padDigits(gameClock.getTimeValues().minutes));
                 $("#gameClockSecs").html(padDigits(gameClock.getTimeValues().seconds));
             }
-            gameClock.addEventListener('secondTenthsUpdated', function (e) {
-                //console.log("GAME CLOCK",gameClock.getTimeValues());
-                if(gameClock.getTimeValues().minutes === 0){
-                    $("#gameClockMins").html(padDigits(gameClock.getTimeValues().seconds));
-                    $("#gameClockSecs").html(gameClock.getTimeValues().secondTenths);
-                }else{
-                    $("#gameClockMins").html(padDigits(gameClock.getTimeValues().minutes));
-                    $("#gameClockSecs").html(padDigits(gameClock.getTimeValues().seconds));
-                }
-            });
 
             startShotClock(shotClockTenthsSecs);
         }
@@ -75,9 +80,6 @@
             var shotClockStartTenths = shotClockTenths || 0;
             shotClock.start({precision: 'secondTenths', countdown: true, startValues: {secondTenths: shotClockStartTenths}});
             $("#shotClockSecs").html(padDigits(shotClock.getTimeValues().seconds));
-            shotClock.addEventListener('secondTenthsUpdated', function (e) {
-                $("#shotClockSecs").html(padDigits(shotClock.getTimeValues().seconds));
-            });
         }
 
         function connect() {


### PR DESCRIPTION
move tenth second time control buttons disable to clock pause event to prevent flicker, also move clock time update event listeners outside of start function.

@wraus/scoreboard-devs 
